### PR TITLE
Add support for the fudge option

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -27,6 +27,7 @@
         var line,
             pad,
             errors,
+            fudge = Number(lint.option.fudge) || 0,
             logger = this.logger,
             fileMessage;
 
@@ -39,8 +40,11 @@
 
         fileMessage = "\n" + c('bold', file);
 
+        function row(e) {
+            return e.line + fudge;
+        }
         function col(e) {
-            return e.character || e.column;
+            return (e.character || e.column) + fudge;
         }
         function evidence(e) {
             return e.evidence || (lint.lines && lint.lines[e.line]) || '';
@@ -58,7 +62,7 @@
 
             if (terse) {
                 errors.forEach(function (e) {
-                    logger.log(file + ':' + e.line + ':' + col(e) + ': ' + message(e));
+                    logger.log(file + ':' + row(e) + ':' + col(e) + ': ' + message(e));
                 });
             } else {
                 logger.log(fileMessage);
@@ -67,7 +71,7 @@
                     while (pad.length < 3) {
                         pad = ' ' + pad;
                     }
-                    line = ' // Line ' + e.line + ', Pos ' + col(e);
+                    line = ' // Line ' + row(e) + ', Pos ' + col(e);
 
                     logger.log(pad + ' ' + c('yellow', message(e)));
                     logger.log('    ' + evidence(e).trim() + c('grey', line));

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -27,7 +27,7 @@
         var line,
             pad,
             errors,
-            fudge = Number(lint.option.fudge) || 0,
+            fudge = Number(lint.option && lint.option.fudge) || 0,
             logger = this.logger,
             fileMessage;
 


### PR DESCRIPTION
JSLint ES6 changes the row and col counting so that they start from 0,0
instead of 1,1.

The fudge option provided by JSLint lets you inform the reporter that you want to add 1 on to the rows and cols.

This update is a fix for issue #135, and provides support for that fudge option.
